### PR TITLE
Implement scheduling, removing need for systemctl units or other timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/conf.py
 run.sh
 cache.json
 images
+status.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ mcstatus==9.4.2
 Pillow==9.2.0
 pycodestyle==2.9.1
 pyflakes==2.5.0
+schedule==1.1.0
 toml==0.10.2

--- a/sample/conf.py.sample
+++ b/sample/conf.py.sample
@@ -15,6 +15,9 @@ REGULAR_FONT_PATH = ""
 # Use italic fonts in certain situations, optional
 ITALIC_FONT_PATH = ""
 
+# How we should check for updates and redraw the image, in seconds
+INTERVAL = 60
+
 # Set to True to enable image rotation
 # Make sure to add images to the images folder!
 IMAGE_ROTATION = False

--- a/sample/conf.py.sample
+++ b/sample/conf.py.sample
@@ -15,7 +15,7 @@ REGULAR_FONT_PATH = ""
 # Use italic fonts in certain situations, optional
 ITALIC_FONT_PATH = ""
 
-# How we should check for updates and redraw the image, in seconds
+# How often we should check for updates, in seconds
 INTERVAL = 60
 
 # Set to True to enable image rotation

--- a/src/argument_handler.py
+++ b/src/argument_handler.py
@@ -17,6 +17,7 @@ from src.conf import (
     SERVER_PORT,
     X_OFFSET,
     TARGET_PATH,
+    INTERVAL,
     IMAGE_ROTATION,
     IMAGE_ROTATION_INTERVAL
 )
@@ -33,6 +34,8 @@ class ArgumentHandler:
     x_offset: float = X_OFFSET or 64
     height: int = int(FIELD_HEIGHT) if FIELD_HEIGHT is not None else None
     opacity: float = FIELD_OPACITY if FIELD_OPACITY is not None else 0.5
+
+    interval: int = int(INTERVAL) if INTERVAL is not None else None
 
     image_path: str = IMAGE_PATH
     image_rotation: bool = IMAGE_ROTATION or False
@@ -67,9 +70,13 @@ class ArgumentHandler:
         if "--help" in self.args:
 
             print(f"Usage: {self.name} [options]\n"
-                  "    Paths:\n"
+                  "    Options:\n"
+                  "        --interval <sec>\t\tHow often should we check for updates & draw image, in seconds\n"
                   "        --images\t\t\tEnable image rotation using images folder\n"
-                  "        --interval <sec>\t\tHow often should the image be rotated out, in seconds\n"
+                  "        --rotation-interval <sec>\tHow often should the image be rotated out, in seconds\n"
+                  "        --force\t\t\t\tForce image to update\n"
+                  "\n"
+                  "    Paths:\n"
                   "        -b --image <path>\t\tPath to base image\n"
                   "        -r --font-regular <path>\tPath to regular font\n"
                   "        -i --font-italic <path>\t\tPath to italic font\n"
@@ -88,10 +95,9 @@ class ArgumentHandler:
                   "        --host <host>\t\t\tHost to connect to\n"
                   "        --port <port>\t\t\tPort to connect to\n"
                   "\n"
-                  "    --force\t\t\t\tForce image to update\n"
                   "    --help\t\t\t\tShow this help message\n"
                   "\n"
-                  "    Permanent options can be set in conf.py\n"
+                  "    Permanent options can be set in src/conf.py\n"
                   )
             exit()
 
@@ -132,6 +138,8 @@ class ArgumentHandler:
                 case "--port":
                     self.port = self.parse_int(self.next_arg(i), arg)
                 case "--interval":
+                    self.interval = self.parse_int(self.next_arg(i), arg)
+                case "--rotation-interval":
                     self.image_rotation_interval = self.parse_int(self.next_arg(i), arg)
                 case "--images":
                     self.image_rotation = True

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -32,8 +32,8 @@ class Canvas:
     bot_left: tuple
     bot_right: tuple
 
-    bot_left_row: TextRow = TextRow()
-    bot_right_row: TextRow = TextRow(direction=RowDirection.Left)
+    bot_left_row: TextRow
+    bot_right_row: TextRow
 
     def __init__(
         self,
@@ -50,6 +50,9 @@ class Canvas:
         opacity: float,
         field_height: int
     ):
+        self.bot_left_row = TextRow()
+        self.bot_right_row = TextRow(direction=RowDirection.Left)
+
         self.image = Image.open(image_path).convert("RGB")
         self.text_l = text_left
         self.text_r = text_right

--- a/src/data_cache.py
+++ b/src/data_cache.py
@@ -4,15 +4,15 @@ import json
 
 class DataCache:
 
-    max_players: int = 0
-    online_players: int = 0
-    name: str = None
-    motd: str = None
-    favicon: str = None
-    version: str = None
-    active: bool = False
-    last_image: str = None
-    last_update: datetime = None
+    max_players: int
+    online_players: int
+    name: str
+    motd: str
+    favicon: str
+    version: str
+    active: bool
+    last_image: str
+    last_update: datetime
 
     def __init__(
         self,

--- a/src/status.py
+++ b/src/status.py
@@ -6,10 +6,12 @@ from src.data_cache import DataCache
 
 class Status:
 
-    cache: DataCache = None
+    cache: DataCache
 
     host: str
     port: int
+
+    server: JavaServer
 
     online_text: str
     offline_text: str
@@ -31,8 +33,11 @@ class Status:
         self.offline_text = offline_text
         self.player_failed_text = player_failed_text
 
+        self.server = JavaServer(self.host, self.port)
+
+    def fetch_status(self):
         try:
-            status = JavaServer(self.host, self.port).status()
+            status = self.server.status()
             self.cache.max_players = status.players.max
             self.cache.online_players = status.players.online
             self.parse_description(status.description)


### PR DESCRIPTION
As the title says, implement scheduling.

The program will no longer need external service timers to do its job. Instead, configure INTERVAL via `src/conf.py`or with the argument `--interval`. It'll then check for any updates as often as specified.